### PR TITLE
all: add initial domain definition and CT Logs client

### DIFF
--- a/api/domain/domain.proto
+++ b/api/domain/domain.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package domain;
+
+// Domain representation.
+message Domain {
+    // Name is the UTF-8 representation of the domain
+    string Name = 1;
+}

--- a/pkg/ct/ct.go
+++ b/pkg/ct/ct.go
@@ -1,0 +1,93 @@
+ package ct
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/darkanhell/Fastphish/api/domain"
+	"github.com/pkg/errors"
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go/client"
+	"github.com/google/certificate-transparency-go/jsonclient"
+)
+
+// CT is a Certificate Transparency client.
+type CT interface {
+	// Handle makes listens for new domains in CT logs.
+	Handle(chan<- domain.Domain) error
+	// Stop allows a client to stop listening for new domains.
+	Stop()
+}
+
+// Client is a generic CT Logs consumer.
+type Client struct {
+	lc *client.LogClient
+	// done channel allows stopping the client.
+	done chan struct{}
+}
+
+// Handle handles new domain names received from CT Logs.
+func (c *Client) Handle(ctx context.Context, start, size int, domains chan<- domain.Domain) error {
+	if start < 0 {
+		return errors.New("start value must be higher or equal to 0")
+	}
+	if size <= 0 {
+		return errors.New("size must be higher or equal to 0")
+	}
+
+	for {
+		select {
+		case <-c.done:
+			return nil
+		default:
+		}
+
+		re, err := c.lc.GetRawEntries(ctx, int64(start), int64(start+size))
+		if err != nil {
+			return errors.Wrap(err, "could not get raw entry")
+		}
+
+		var index int
+		for _, entry := range re.Entries {
+			le, err := ct.LogEntryFromLeaf(int64(index), &entry)
+			if err != nil {
+				log.Printf("could not convert LeafEntry to LogEntry: %v", err)
+				continue
+			}
+
+			for _, v := range le.X509Cert.DNSNames {
+				domains <- domain.Domain{Name: v}
+			}
+
+			index++
+		}
+	}
+}
+
+// Stop finishes the client.
+func (c *Client) Stop() {
+	close(c.done)
+}
+
+// Option type allows customizing HTTP client.
+type Option func(*http.Client)
+
+// New sets up a CT Logs client.
+func New(ctlog string, opts ...Option) (*Client, error) {
+	hc := &http.DefaultClient
+	for _, opt := range opts {
+		opt(*hc)
+	}
+
+	lc, err := client.New(ctlog, *hc, jsonclient.Options{})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create client")
+	}
+
+	done := make(chan struct{})
+	return &Client{
+		lc: lc,
+		done: done,
+	}, nil
+}

--- a/pkg/ct/ct.go
+++ b/pkg/ct/ct.go
@@ -15,7 +15,7 @@ import (
 // CT is a Certificate Transparency client.
 type CT interface {
 	// Handle makes listens for new domains in CT logs.
-	Handle(chan<- domain.Domain) error
+	Handle(ctx context.Context, start, size int, domains chan<- domain.Domain) error
 	// Stop allows a client to stop listening for new domains.
 	Stop()
 }

--- a/pkg/ct/ct.go
+++ b/pkg/ct/ct.go
@@ -52,6 +52,7 @@ func (c *Client) Handle(ctx context.Context, start, size int, domains chan<- dom
 		for _, entry := range re.Entries {
 			le, err := ct.LogEntryFromLeaf(int64(index), &entry)
 			if err != nil {
+				// TODO: switch to a real logger.
 				log.Printf("could not convert LeafEntry to LogEntry: %v", err)
 				continue
 			}


### PR DESCRIPTION
This PR adds an initial simple domain names protobuf definition and the first implementation of the Certificate Transparency Logs client.